### PR TITLE
Load dungeon settings in dependency order

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -41,11 +41,11 @@ developmentEnvironmentUserName = "Developer"
 
 # Enables using modern Java syntax (up to version 17) via Jabel, while still targeting JVM 8.
 # See https://github.com/bsideup/jabel for details on how this works.
-enableModernJavaSyntax = false
+enableModernJavaSyntax = true
 
 # Enables injecting missing generics into the decompiled source code for a better coding experience.
 # Turns most publicly visible List, Map, etc. into proper List<E>, Map<K, V> types.
-enableGenericInjection = false
+enableGenericInjection = true
 
 # Generate a class with a String field for the mod version named as defined below.
 # If generateGradleTokenClass is empty or not missing, no such class will be generated.

--- a/src/main/java/greymerk/roguelike/dungeon/settings/DungeonSettings.java
+++ b/src/main/java/greymerk/roguelike/dungeon/settings/DungeonSettings.java
@@ -38,7 +38,7 @@ public class DungeonSettings implements ISettings {
         levels = new HashMap<Integer, LevelSettings>();
         this.depth = 0;
 
-        this.name = root.get("name").getAsString();
+        this.name = readDungeonName(root);
         if (root.has("criteria")) this.criteria = new SpawnCriteria(root.get("criteria").getAsJsonObject());
         if (root.has("tower")) this.towerSettings = new TowerSettings(root.get("tower"));
         if (root.has("loot_rules")) this.lootRules = new LootRuleManager(root.get("loot_rules"));
@@ -59,17 +59,9 @@ public class DungeonSettings implements ISettings {
             }
         }
 
-        List<String> inheritList = new ArrayList<String>();
-        if (root.has("inherit")) {
-            JsonArray inherit = root.get("inherit").getAsJsonArray();
-            for (JsonElement e : inherit) {
-                inheritList.add(e.getAsString());
-            }
-        }
-
         // generate an inherit base and then apply inherited aspects.
         DungeonSettings base = new SettingsBlank();
-        for (String name : inheritList) {
+        for (String name : readDungeonInheritance(root)) {
             if (settings.containsKey(name)) {
                 base = new DungeonSettings(base, settings.get(name));
             } else {
@@ -103,6 +95,21 @@ public class DungeonSettings implements ISettings {
 
             this.levels.put(i, setting);
         }
+    }
+
+    static String readDungeonName(JsonObject root) {
+        return root.get("name").getAsString();
+    }
+
+    static List<String> readDungeonInheritance(JsonObject root) {
+        List<String> inheritList = new ArrayList<>();
+        if (root.has("inherit")) {
+            JsonArray inherit = root.get("inherit").getAsJsonArray();
+            for (JsonElement e : inherit) {
+                inheritList.add(e.getAsString());
+            }
+        }
+        return inheritList;
     }
 
     public DungeonSettings(DungeonSettings base, DungeonSettings override) {

--- a/src/main/java/greymerk/roguelike/treasure/loot/LootRuleManager.java
+++ b/src/main/java/greymerk/roguelike/treasure/loot/LootRuleManager.java
@@ -117,6 +117,7 @@ public class LootRuleManager {
             try {
                 item = new WeightedRandomLoot(data, weight);
             } catch (Exception e) {
+                System.err.println("Invalid loot item replaced with a stick: " + data.toString());
                 System.err.println(e.getMessage());
                 item = new WeightedRandomLoot(Items.stick, 1);
             }


### PR DESCRIPTION
This PR has 2 benefits:
- You can add dungeon setting dependencies no matter the file name.
- You get an error message telling you when your dungeon couldn't be loaded due to non-existent dependencies, or dependencies which themselves had missing dependencies.

I also enhanced logging of invalid loot configurations.

With the current configuration of nightlies, these are the current incorrect dependencies which will need to be resolved in the loot pool PR:
```
[22:25:59] [Server thread/INFO] [STDERR]: [greymerk.roguelike.dungeon.settings.SettingsResolver:logUnloadedDungeons:163]: Dungeon dungeon_jungle.json not loaded because of unmet dependencies
[22:25:59] [Server thread/INFO] [STDERR]: [greymerk.roguelike.dungeon.settings.SettingsResolver:logUnloadedDungeons:164]: Unmet dependencies: [loot_all, loot_jungle_temp, rooms_jungle, size]
[22:26:00] [Server thread/INFO] [STDERR]: [greymerk.roguelike.dungeon.settings.SettingsResolver:logUnloadedDungeons:163]: Dungeon dungeon_forest.json not loaded because of unmet dependencies
[22:26:00] [Server thread/INFO] [STDERR]: [greymerk.roguelike.dungeon.settings.SettingsResolver:logUnloadedDungeons:164]: Unmet dependencies: [loot_all, loot_forest_temp, theme_forest, segments_forest, size]
[22:26:01] [Server thread/INFO] [STDERR]: [greymerk.roguelike.dungeon.settings.SettingsResolver:logUnloadedDungeons:163]: Dungeon dungeon_mesa.json not loaded because of unmet dependencies
[22:26:01] [Server thread/INFO] [STDERR]: [greymerk.roguelike.dungeon.settings.SettingsResolver:logUnloadedDungeons:164]: Unmet dependencies: [loot_all, loot_mesa_temp, theme_mesa, rooms_mesa, segments_mesa, size]
[22:26:02] [Server thread/INFO] [STDERR]: [greymerk.roguelike.dungeon.settings.SettingsResolver:logUnloadedDungeons:163]: Dungeon dungeon_swamp.json not loaded because of unmet dependencies
[22:26:02] [Server thread/INFO] [STDERR]: [greymerk.roguelike.dungeon.settings.SettingsResolver:logUnloadedDungeons:164]: Unmet dependencies: [loot_all, loot_swamp_temp, size]
[22:26:05] [Server thread/INFO] [STDERR]: [greymerk.roguelike.dungeon.settings.SettingsResolver:logUnloadedDungeons:163]: Dungeon loot_all.json not loaded because of unmet dependencies
[22:26:05] [Server thread/INFO] [STDERR]: [greymerk.roguelike.dungeon.settings.SettingsResolver:logUnloadedDungeons:164]: Unmet dependencies: [loot_ore_temp, loot_blocks_temp, loot_potions_temp]
[22:26:06] [Server thread/INFO] [STDERR]: [greymerk.roguelike.dungeon.settings.SettingsResolver:logUnloadedDungeons:163]: Dungeon dungeon_plains.json not loaded because of unmet dependencies
[22:26:06] [Server thread/INFO] [STDERR]: [greymerk.roguelike.dungeon.settings.SettingsResolver:logUnloadedDungeons:164]: Unmet dependencies: [loot_all, loot_plains_temp, segments_plains, size]
[22:26:07] [Server thread/INFO] [STDERR]: [greymerk.roguelike.dungeon.settings.SettingsResolver:logUnloadedDungeons:163]: Dungeon loot_builtin_override.json not loaded because of unmet dependencies
[22:26:07] [Server thread/INFO] [STDERR]: [greymerk.roguelike.dungeon.settings.SettingsResolver:logUnloadedDungeons:164]: Unmet dependencies: [loot_all]
[22:26:08] [Server thread/INFO] [STDERR]: [greymerk.roguelike.dungeon.settings.SettingsResolver:logUnloadedDungeons:163]: Dungeon dungeon_mountain.json not loaded because of unmet dependencies
[22:26:08] [Server thread/INFO] [STDERR]: [greymerk.roguelike.dungeon.settings.SettingsResolver:logUnloadedDungeons:164]: Unmet dependencies: [loot_all, loot_mountain_temp, size]
[22:26:09] [Server thread/INFO] [STDERR]: [greymerk.roguelike.dungeon.settings.SettingsResolver:logUnloadedDungeons:163]: Dungeon dungeon_desert.json not loaded because of unmet dependencies
[22:26:09] [Server thread/INFO] [STDERR]: [greymerk.roguelike.dungeon.settings.SettingsResolver:logUnloadedDungeons:164]: Unmet dependencies: [loot_all, loot_desert_temp, size]
```